### PR TITLE
Add 'py3-packaging' to system package installations

### DIFF
--- a/1.19-alpine/Dockerfile
+++ b/1.19-alpine/Dockerfile
@@ -14,7 +14,8 @@ RUN apk update && apk add \
     python3 \
     py3-pip \
     py3-distlib \
-    py3-six
+    py3-six \
+    py3-packaging
 
 # Upgrade PIP & install replace_domain
 # Copy python dependencies list

--- a/1.20-alpine/Dockerfile
+++ b/1.20-alpine/Dockerfile
@@ -14,7 +14,8 @@ RUN apk update && apk add \
     python3 \
     py3-pip \
     py3-distlib \
-    py3-six
+    py3-six \
+    py3-packaging
 
 # Upgrade PIP & install replace_domain
 # Copy python dependencies list

--- a/1.21-alpine/Dockerfile
+++ b/1.21-alpine/Dockerfile
@@ -13,7 +13,8 @@ RUN apk update && apk add \
     bash \
     python3 \
     py3-pip \
-    py3-distlib
+    py3-distlib \
+    py3-packaging
 
 # Upgrade PIP & install replace_domain
 # Copy python dependencies list

--- a/1.22-alpine/Dockerfile
+++ b/1.22-alpine/Dockerfile
@@ -12,7 +12,8 @@ ENV port=5000
 RUN apk update && apk add \
     bash \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging
 
 # Upgrade PIP & install replace_domain
 # Copy python dependencies list

--- a/1.23-alpine/Dockerfile
+++ b/1.23-alpine/Dockerfile
@@ -12,7 +12,8 @@ ENV port=5000
 RUN apk update && apk add \
     bash \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging
 
 # Upgrade PIP & install replace_domain
 # Copy python dependencies list

--- a/1.24-alpine/Dockerfile
+++ b/1.24-alpine/Dockerfile
@@ -12,7 +12,8 @@ ENV port=5000
 RUN apk update && apk add \
     bash \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging
 
 # Upgrade PIP & install replace_domain
 # Copy python dependencies list

--- a/1.25-alpine/Dockerfile
+++ b/1.25-alpine/Dockerfile
@@ -12,7 +12,8 @@ ENV port=5000
 RUN apk update && apk add \
     bash \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt


### PR DESCRIPTION
- add 'py3-packaging' to system package installations as it is a disutil that can't be reliably installed via pip