### PR TITLE
'six' Python package installation

### DIFF
--- a/1.21-alpine/requirements.txt
+++ b/1.21-alpine/requirements.txt
@@ -19,7 +19,7 @@ pyparsing==3.1.2
 replace_domain==1.0.5
 requests==2.32.2
 retrying==1.3.4
-six==1.16.0
+six>=1.16.0
 toml==0.10.2
 tomli==2.0.1
 urllib3==2.2.1

--- a/1.22-alpine/requirements.txt
+++ b/1.22-alpine/requirements.txt
@@ -3,4 +3,4 @@ packaging>=21.3
 pyparsing==3.1.2
 replace_domain==1.0.5
 retrying==1.3.4
-six==1.16.0
+six>=1.16.0

--- a/1.23-alpine/requirements.txt
+++ b/1.23-alpine/requirements.txt
@@ -3,4 +3,4 @@ packaging>=21.3
 pyparsing==3.1.2
 replace_domain==1.0.5
 retrying==1.3.4
-six==1.16.0
+six>=1.16.0

--- a/1.24-alpine/requirements.txt
+++ b/1.24-alpine/requirements.txt
@@ -3,4 +3,4 @@ packaging>=21.3
 pyparsing==3.1.2
 replace_domain==1.0.5
 retrying==1.3.4
-six==1.16.0
+six>=1.16.0


### PR DESCRIPTION
- fix 'six' version constaints in requirements.txt to allow for system packages to install the latest version